### PR TITLE
Group chat consistency

### DIFF
--- a/docs/client/design.md
+++ b/docs/client/design.md
@@ -115,9 +115,9 @@ Support for multiple accounts is OPTIONAL.
     Research recommendations for the best way to handle multiple accounts. E.g. merge contacts, or not.
     Not required. Describe how to display multiple accounts in a single client?
 
-## Group Chat
+## Group chat
 
-You can find more details about [Group Chats here](groupchat.md).
+You can find more details about [group chats here](groupchat.md).
 
 ## Documentation
 
@@ -139,7 +139,7 @@ Clients must not reveal full JID. Don't query unsubscribed contacts.
 When displaying messages received from a remote JID, either within a one-to-one or multi-user chat, clients need to show a human-readable
 name for that sender.
 
-There are multiple sources for such a display name, which depend on the context (e.g. whether the conversation is a private or Group Chat).
+There are multiple sources for such a display name, which depend on the context (e.g. whether the conversation is one-to-one or a group chat).
 
 ### Name sources
 

--- a/docs/client/design.md
+++ b/docs/client/design.md
@@ -115,7 +115,7 @@ Support for multiple accounts is OPTIONAL.
     Research recommendations for the best way to handle multiple accounts. E.g. merge contacts, or not.
     Not required. Describe how to display multiple accounts in a single client?
 
-## Group chat
+## Group Chat
 
 You can find more details about [Group Chats here](groupchat.md).
 
@@ -139,7 +139,7 @@ Clients must not reveal full JID. Don't query unsubscribed contacts.
 When displaying messages received from a remote JID, either within a one-to-one or multi-user chat, clients need to show a human-readable
 name for that sender.
 
-There are multiple sources for such a display name, which depend on the context (e.g. whether the conversation is a private or group chat).
+There are multiple sources for such a display name, which depend on the context (e.g. whether the conversation is a private or Group Chat).
 
 ### Name sources
 

--- a/docs/client/groupchat.md
+++ b/docs/client/groupchat.md
@@ -2,11 +2,11 @@
 
 ## Types of chat
 
-There are two kinds of multi-user chat. Private Group Chats, and public channels.
+There are two kinds of multi-user chat. Private *group chats*, and public *channels*.
 
 ### Properties
 
-|                  | Group Chat | Channel |
+|                  | Group chat | Channel |
 |:-----------------|:-----------|:--------|
 | Persistent       | Yes        | Yes     |
 | MAM enabled      | Yes        | Yes     |
@@ -16,28 +16,28 @@ There are two kinds of multi-user chat. Private Group Chats, and public channels
 | Publicly listed  | No  (\*)   | Yes     |
 | PMs              | No  (\*)   | Yes     |
 
-(\*) Immutable for Group Chats.
+(\*) Immutable for *group chats*.
 
 ### Terminology
 
-People in the Group Chat / channel: Participants
+People in the *group chat* / *channel*: *Participants*
 
 Roles are not displayed and cannot be modified through the UI.
 
 
-| Affiliations | In Group Chats | In channels |
-|:-------------|:-------------:|:-----------:|
-| none         | N/A **        | Guest       |
-| member       | -             | -           |
-| admin        | *Admin* (\*)  | Admin       |
-| owner        | Owner         | Owner       |
+| Affiliations | In group chats | In channels |
+|:-------------|:--------------:|:-----------:|
+| none         | N/A **         | Guest       |
+| member       | -              | -           |
+| admin        | *Admin* (\*)   | Admin       |
+| owner        | Owner          | Owner       |
 
-(\*) A Group Chat will display an existing admin as such but it will not encourage/allow
-someone to be promoted to admin. UI options in Group Chats only allow a member to become
+(\*) A *group chat* will display an existing admin as such but it will not encourage/allow
+someone to be promoted to admin. UI options in *group chats* only allow a member to become
 an owner but not admin. So admins are discouraged by the UI but will be displayed as such
 if the end up being one for some reason.
 
-(\*\*) Everybody is a member in Group Chats
+(\*\*) Everybody is a member in *group chats*
 
 Clients MAY create an 'advanced view' that displays roles as well.
 

--- a/docs/client/groupchat.md
+++ b/docs/client/groupchat.md
@@ -2,11 +2,11 @@
 
 ## Types of chat
 
-There are two kinds of multi-user chat. Private group chats, and public channels.
+There are two kinds of multi-user chat. Private Group Chats, and public channels.
 
 ### Properties
 
-|                  | Group chat | Channel |
+|                  | Group Chat | Channel |
 |:-----------------|:-----------|:--------|
 | Persistent       | Yes        | Yes     |
 | MAM enabled      | Yes        | Yes     |
@@ -16,28 +16,28 @@ There are two kinds of multi-user chat. Private group chats, and public channels
 | Publicly listed  | No  (\*)   | Yes     |
 | PMs              | No  (\*)   | Yes     |
 
-(\*) Immutable for group chats.
+(\*) Immutable for Group Chats.
 
 ### Terminology
 
-People in the group chat / channel: Participants
+People in the Group Chat / channel: Participants
 
 Roles are not displayed and cannot be modified through the UI.
 
 
-| Affiliations | In groupchats | In channels |
+| Affiliations | In Group Chats | In channels |
 |:-------------|:-------------:|:-----------:|
 | none         | N/A **        | Guest       |
 | member       | -             | -           |
 | admin        | *Admin* (\*)  | Admin       |
 | owner        | Owner         | Owner       |
 
-(\*) A group chat will display an existing admin as such but it will not encourage/allow
-someone to be promoted to admin. UI options in group chats only allow a member to become
+(\*) A Group Chat will display an existing admin as such but it will not encourage/allow
+someone to be promoted to admin. UI options in Group Chats only allow a member to become
 an owner but not admin. So admins are discouraged by the UI but will be displayed as such
 if the end up being one for some reason.
 
-(\*\*) Everybody is a member in groupchats
+(\*\*) Everybody is a member in Group Chats
 
 Clients MAY create an 'advanced view' that displays roles as well.
 

--- a/docs/client/protocol.md
+++ b/docs/client/protocol.md
@@ -168,7 +168,7 @@ implement this mechanism to provide the best user experience.
 #### Benefits
 
 - Does not depend on the recipient supporting it (simply falls back to sending a URL)
-- Works with Group Chats
+- Works with group chats
 - Works when the recipient is offline
 - Allows the recipient to receive on multiple devices
 
@@ -224,7 +224,7 @@ it suitable for larger files.
 - Because it is a multi-purpose framework it can be complex.
 - Not all clients support it.
 - In the case of the recipient having multiple devices, only a single one can receive the file.
-- Does not work for sharing a file with multiple people (e.g. in a Group Chat)
+- Does not work for sharing a file with multiple people (e.g. in a group chat)
 - Only works if the recipient is online
 
 !!! note
@@ -254,14 +254,14 @@ is required (and HTTP Upload does not suffice for some reason).
 
 - Deprecated. Modern clients are switching to Jingle negotiation.
 - In the case of the recipient having multiple devices, only a single one can receive the file.
-- Does not work for sharing a file with multiple people (e.g. in a Group Chat)
+- Does not work for sharing a file with multiple people (e.g. in a group chat)
 - Only works if the recipient is online
 
 ## Avatars
 
 TODO
 
-## Group Chat
+## Group chat
 
 TODO
 
@@ -293,7 +293,7 @@ encryption protocol "OTR".
 Although it sufficed for simple use cases (sender and recipient have
 a single device connected, and both support OTR), it has a number of
 drawbacks when used within XMPP. Traditionally it has not supported multiple devices
-very well, nor Group Chats, and it only protects the message body.
+very well, nor group chats, and it only protects the message body.
 
 These issues lead to a poor user experience.
 

--- a/docs/client/protocol.md
+++ b/docs/client/protocol.md
@@ -168,7 +168,7 @@ implement this mechanism to provide the best user experience.
 #### Benefits
 
 - Does not depend on the recipient supporting it (simply falls back to sending a URL)
-- Works with group chats
+- Works with Group Chats
 - Works when the recipient is offline
 - Allows the recipient to receive on multiple devices
 
@@ -224,7 +224,7 @@ it suitable for larger files.
 - Because it is a multi-purpose framework it can be complex.
 - Not all clients support it.
 - In the case of the recipient having multiple devices, only a single one can receive the file.
-- Does not work for sharing a file with multiple people (e.g. in a group chat)
+- Does not work for sharing a file with multiple people (e.g. in a Group Chat)
 - Only works if the recipient is online
 
 !!! note
@@ -254,14 +254,14 @@ is required (and HTTP Upload does not suffice for some reason).
 
 - Deprecated. Modern clients are switching to Jingle negotiation.
 - In the case of the recipient having multiple devices, only a single one can receive the file.
-- Does not work for sharing a file with multiple people (e.g. in a group chat)
+- Does not work for sharing a file with multiple people (e.g. in a Group Chat)
 - Only works if the recipient is online
 
 ## Avatars
 
 TODO
 
-## Group chat
+## Group Chat
 
 TODO
 
@@ -293,7 +293,7 @@ encryption protocol "OTR".
 Although it sufficed for simple use cases (sender and recipient have
 a single device connected, and both support OTR), it has a number of
 drawbacks when used within XMPP. Traditionally it has not supported multiple devices
-very well, nor group chats, and it only protects the message body.
+very well, nor Group Chats, and it only protects the message body.
 
 These issues lead to a poor user experience.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ and thus make it possible to identify and weed out software that falls behind th
 
 It's early days. We are still building the foundations of what will become the initial set of documents. Nevertheless, we already have a bunch of stuff documented that developers of XMPP software (both new and experienced) will find useful. This includes [design guidelines](client/design.md) and lower-level [protocol implementation recommendations](client/protocol.md).
 
-If you're interested in joining us, our primary discussion venue is our chatroom which can be reached at:
+If you're interested in joining us, our primary discussion venue is our channel which can be reached at:
 
 - XMPP: [modernxmpp@rooms.modernxmpp.org](xmpp:modernxmpp@rooms.modernxmpp.org?join)
 - Web: [chat.modernxmpp.org](https://chat.modernxmpp.org/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ and thus make it possible to identify and weed out software that falls behind th
 
 It's early days. We are still building the foundations of what will become the initial set of documents. Nevertheless, we already have a bunch of stuff documented that developers of XMPP software (both new and experienced) will find useful. This includes [design guidelines](client/design.md) and lower-level [protocol implementation recommendations](client/protocol.md).
 
-If you're interested in joining us, our primary discussion venue is our channel which can be reached at:
+If you're interested in joining us, our primary discussion venue is our *channel* which can be reached at:
 
 - XMPP: [modernxmpp@rooms.modernxmpp.org](xmpp:modernxmpp@rooms.modernxmpp.org?join)
 - Web: [chat.modernxmpp.org](https://chat.modernxmpp.org/)

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -5,9 +5,9 @@ terms.
 
 | Historic terms                   | Recommended terms                                     |
 |----------------------------------|-------------------------------------------------------|
-| MUC, Room, Chatroom, Conference  | 'Group Chat' or 'Channel' (see [Multi-user Chats][])  |
-| Occupant                         | 'Participant'                                         |
-| JID                              | 'Address' or 'XMPP address'                           |
-| Roster                           | 'Contact list'                                        |
+| MUC, Room, Chatroom, Conference  | *Group chat* or *Channel* (see [Multi-user Chats][])  |
+| Occupant                         | *Participant*                                         |
+| JID                              | *Address* or *XMPP address*                           |
+| Roster                           | *Contact list*                                        |
 
 [Multi-user Chats]: client/groupchat.md


### PR DESCRIPTION
This replaces `groupchat` by `group chat` and puts emphasis both terms `group chat` and `channel` where appropriate.

Also, this makes use of the new `Channel` term on the frontpage.