### PR TITLE
mkdocs.yml: Set site base URL (fixes sitemap.xml)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ markdown_extensions:
   - toc:
       permalink: true
 
+site_url: https://docs.modernxmpp.org/
 repo_url: https://github.com/modernxmpp/modernxmpp
 edit_uri: edit/draft/docs
 


### PR DESCRIPTION
<https://docs.modernxmpp.org/sitemap.xml> lists every location as `None` presumably because of this missing config option.