### PR TITLE
Replace instances of "JID" with "XMPP address"

### DIFF
--- a/docs/client/design.md
+++ b/docs/client/design.md
@@ -11,7 +11,7 @@ please [open an issue or pull request](https://github.com/modernxmpp/modernxmpp)
 
 ## Initial configuration
 
-At initial startup, a client should present a welcome screen, to prompt the user for their JID,
+At initial startup, a client should present a welcome screen, to prompt the user for their XMPP address,
 and a password. Optionally, a button or link to provide other forms of credentials may be included.
 
 If the client has an out-of-band configuration mechanism, or it can query the OS for sensible defaults,
@@ -22,10 +22,10 @@ List recommended configuration options.
 
 ### Account
 
-| Option | Description           |
-|:-------|:----------------------|
-| JID    | The user's JID        |
-| Password | The user's password |
+| Option       | Description            |
+|:-------------|:-----------------------|
+| XMPP address | The user's XMPP address|
+| Password     | The user's password    |
 
 ### Network
 
@@ -128,7 +128,7 @@ Clients should have documentation covering essential functionality, including:
 
 ## Privacy
 
-Clients must not reveal full JID. Don't query unsubscribed contacts.
+Clients must not reveal full XMPP address. Don't query unsubscribed contacts.
 
 !!! todo
     Probably belongs in protocol reference. Probably some things relevant
@@ -136,7 +136,7 @@ Clients must not reveal full JID. Don't query unsubscribed contacts.
 
 ## Names
 
-When displaying messages received from a remote JID, either within a one-to-one or multi-user chat, clients need to show a human-readable
+When displaying messages received from a remote XMPP address, either within a one-to-one or multi-user chat, clients need to show a human-readable
 name for that sender.
 
 There are multiple sources for such a display name, which depend on the context (e.g. whether the conversation is one-to-one or a group chat).
@@ -155,13 +155,13 @@ User nickname
 : A nickname published by the sender in PEP per [XEP-0172](https://xmpp.org/extensions/xep-0172.html).
 
 Resource
-: The resource of the sending JID.
+: The resource of the sending XMPP address.
 
 Local part
-: The part of a bare JID before the '@' symbol.
+: The part of a bare XMPP address before the '@' symbol.
 
-Bare JID
-: The sending JID with any resource removed.
+Bare XMPP address
+: The sending XMPP address with any resource removed.
 
 ### Contexts
 
@@ -173,8 +173,8 @@ should be checked in the order described by the table below, displaying the firs
 | Conversation - normal   | Roster name, (Address book), User nickname, Local part    |
 | Conversation - group    | Roster name, (Address book), User nickname, Resource (\*) |
 | Conversation - channel  | Resource                                                  |
-| Contact list            | Roster name, User nickname, Bare JID                      |
-| User profile            | Roster name, User nickname, Bare JID                      |
+| Contact list            | Roster name, User nickname, Bare XMPP address             |
+| User profile            | Roster name, User nickname, Bare XMPP address             |
 
 (\*) Mentions refer to resource. if you do proper references you can live replace it with the 'nice' name.
 

--- a/docs/client/groupchat.md
+++ b/docs/client/groupchat.md
@@ -6,15 +6,15 @@ There are two kinds of multi-user chat. Private *group chats*, and public *chann
 
 ### Properties
 
-|                  | Group chat | Channel |
-|:-----------------|:-----------|:--------|
-| Persistent       | Yes        | Yes     |
-| MAM enabled      | Yes        | Yes     |
-| Subject editable | No         | No      |
-| Members-only     | Yes (\*)   | No      |
-| JIDs revealed    | Yes (\*)   | No      |
-| Publicly listed  | No  (\*)   | Yes     |
-| PMs              | No  (\*)   | Yes     |
+|                         | Group chat | Channel |
+|:------------------------|:-----------|:--------|
+| Persistent              | Yes        | Yes     |
+| MAM enabled             | Yes        | Yes     |
+| Subject editable        | No         | No      |
+| Members-only            | Yes (\*)   | No      |
+| XMPP addresses revealed | Yes (\*)   | No      |
+| Publicly listed         | No  (\*)   | Yes     |
+| PMs                     | No  (\*)   | Yes     |
 
 (\*) Immutable for *group chats*.
 
@@ -64,8 +64,8 @@ User nickname (vCard)
 Local nickname
 : (Optional, not recommended[^local-nickname]) A nickname previously configured by the user in this client instance.
 
-JID username
-: The username portion of the user's JID (i.e. before the '@').
+XMPP address username
+: The username portion of the user's XMPP address (i.e. before the '@').
 
 ### Other user's names
 
@@ -78,16 +78,16 @@ The display of other user's names is covered in the [general UI recommendations]
 
 ## Private messages
 
-Clients must always use real JIDs for messaging privately within a *group chat* if (and only if) JIDs are publicly visible to all participants.[^pm-realjid]
+Clients must always use real XMPP addresses for messaging privately within a *group chat* if (and only if) XMPP addresses are publicly visible to all participants.[^pm-realjid]
 
 <!-- Footnotes -->
 
 [^rationale-gc]: Rationale [group chats](/rationale#group-chats)
 [^local-nickname]: To avoid requiring the user to configure a nickname manually on each device, shared cross-device stores such as PEP and vCard should be preferred.
-[^pm-realjid]: If real JIDs are known to all participants, it is preferable to use that for private communication to avoid confusion. Through-MUC PMs have the following disadvantages:
+[^pm-realjid]: If real XMPP addresses are known to all participants, it is preferable to use that for private communication to avoid confusion. Through-MUC PMs have the following disadvantages:
 
     - Only work while connected to the group chat
     - Do not interact well with multiple devices (e.g. not all of a recipient's devices may be in a group chat)
     - Can cause confusion if talking to the same person through different views (e.g. if the person is already a contact in your roster, and you already have a chat open with them)
 
-    However if the sending user is an admin of a room where JIDs are hidden, using a real JID will reveal the admin's private JID to the recipient. Either warn the sender that their JID will be revealed, or always use the in-room JID in such channels.
+    However if the sending user is an admin of a room where XMPP addresses are hidden, using a real XMPP addresses will reveal the admin's private XMPP addresses to the recipient. Either warn the sender that their XMPP addresses will be revealed, or always use the in-room XMPP address in such channels.

--- a/docs/client/protocol.md
+++ b/docs/client/protocol.md
@@ -268,7 +268,7 @@ TODO
 
 ### Blocking
 
-- [XEP-0191](https://xmpp.org/extensions/xep-0191.html) for blocking communication with a list of other JIDs
+- [XEP-0191](https://xmpp.org/extensions/xep-0191.html) for blocking communication with a list of other XMPP addresses
 
 ## Encryption
 


### PR DESCRIPTION
As mentioned in terminology.md, "XMPP address" should supersede "JID".