### PR TITLE
client: add beginnings of history sync docs

### DIFF
--- a/docs/client/sync.md
+++ b/docs/client/sync.md
@@ -1,0 +1,32 @@
+# Syncing Message History
+
+## MAM Strategies
+
+Fetching history from the server is accomplished with [Message Archive
+Management][MAM] (MAM).
+New XMPP clients frequently use naïve methods of querying history that result in
+long wait times for history, or frozen UIs.
+However, a robust strategy for fetching history has not been previously
+documented.
+This section documents strategies used by clients in the wild, as well as
+implementation recommendations for MAM.
+
+### Requirements
+
+- Allow the user to send a message in response to history fetched from the
+  server as quickly as possible
+- Do not generate dozens of notifications for old messages
+
+### Implementation Notes
+
+- Don't treat history like normal incoming messages.
+  If querying lots of messages, aggregate and commit them to the data store
+  (assuming a transactional database) as a group.
+  Do the same for updating the UI and displaying notifications.
+- Look up the last message _before_ sending initial presence, otherwise you
+  may receive a message before you get the last ID and end up with a gap.
+- If using paging, committing one page at a time to the DB/UI is a natural way
+  to break up large transactions and provide the user with quicker feeling
+  updates.
+
+[MAM]: https://xmpp.org/extensions/xep-0313.html


### PR DESCRIPTION
This adds some implementation recommendations for MAM. It does not, however, do what it promises and document what existing clients are doing. I can only speak for Mellium/Communiqué, and that's experimental and probably not worth including on this page. I believe Dino just fetches all history from the beginning of time (or the last seen message), but I can't be sure and didn't want to speak for them.

This is really just the start of this page, but it's more or less all I can do on my own (unless you want me to document my own unproven sync strategy). I'll try to drum up more conversation about what others are doing/ideal sync strategies.