### PR TITLE
Update /client/invites/ with latest XEPs

### DIFF
--- a/docs/client/invites.md
+++ b/docs/client/invites.md
@@ -1,23 +1,47 @@
 # Registration through invitation
 
+It is possible to create invitation links in XMPP. There are currently a few
+types of invitation possible, e.g. you may be invited to register on a server,
+or be invited to add someone as a contact, or both.
+
 ## Invitation types
+
+There are three types of invitation:
+
+- [Account-only](#account-only)
+- [Subscription-only](#subscription-only)
+- [Account-and-subscription](#account-and-subscription)
+
+They are described individually in the following sections.
 
 ### Account-only
 
-Invitation to register an account on a given domain:
+This type of invitation can be used by server operators to allow
+people to create accounts on their server, without needing to open up
+registration to the public.
+
+#### Format
+
+Invitation to register an account on a given domain (e.g. 'example.com'):
+
 ```
 xmpp:example.com?register;preauth=3c7efeafc1bb10d034
 ```
-or an invitation to register an account with a **specific** username
-only:
+or an invitation to register an account with a **specific** username (e.g.
+'romeo') only:
+
 ```
 xmpp:romeo@example.com?register;preauth=3c7efeafc1bb10d034
 ```
 
-See the *Registration protocol* section of this document for how to
-handle this type of invitation.
+See [XEP-0445][] for how to register an account using this type of invitation.
 
 ### Subscription-only
+
+This invitation type can be shared with someone who you would
+like to add you as a contact. Unlike a normal XMPP subscription request, these
+invitations can be shared to people via any mechanism (e.g. email, SMS, web)
+and if you don't know the recipient's XMPP address or they don't yet have one.
 
 A potential contact invites you to communicate with them:
 ```
@@ -25,9 +49,8 @@ xmpp:contact@example.com?roster;preauth=3c7efeafc1bb10d034
 ```
 
 The protocol to handle this type of invitation is specified in
-[XEP-0379: Pre-authenticated Roster Subscriptions](https://xmpp.org/extensions/xep-0379.html).
-After following the protocol, you will have a mutual presence subscription
-with `contact@example.com`.
+[XEP-0379][]. After following the protocol, you will have a mutual presence
+subscription with `contact@example.com`.
 
 If the user does not currently have an account, the client must walk
 them through the account registration process on a suitable XMPP service.
@@ -42,80 +65,43 @@ domain, signalled by the presence of `ibr=y` in the URI parameters:
 xmpp:contact@example.com?roster;preauth=3c7efeafc1bb10d034;ibr=y
 ```
 
-If the recipient of such an invite does not yet have an account, the
+If the recipient of such an invite does not yet have an XMPP account, their
 client should follow the *Registration protocol* section of this document.
 After completing the registration, the user will automatically be subscribed
 to the sender of the invitation.
 
 If the recipient already has an XMPP account, the invitation should be
 handled the same as a subscription-only invitation documented above,
-and follow the protocol defined in [XEP-0379](https://xmpp.org/extensions/xep-0379.html).
+and follow the protocol defined in [XEP-0379][].
 
-# Registration protocol
+## Protocols
 
-Server sends stream features:
+There are three standards governing the creation and consumption of invitations:
 
-```xml
-<stream:features>
-  <mechanisms xmlns='urn:xmpp:sasl:0'>
-    <mechanism>EXTERNAL</mechanism>
-    <mechanism>SCRAM-SHA-1-PLUS</mechanism>
-    <mechanism>SCRAM-SHA-1</mechanism>
-    <mechanism>PLAIN</mechanism>
-  </mechanisms>
-  <register xmlns='urn:xmpp:invite'/>
-  <register xmlns='http://jabber.org/features/iq-register'/>
-</stream:features>
-```
+- [XEP-0401][] - describes how to create new invitations (of all types).
+- [XEP-0445][] - describes how to register an account using an account-only or account-and-subscription invitation.
+- [XEP-0379][] - describes how to convert an invitation (subscription-only or account-and-subscription types) into a roster subscription.
 
-Client sees that registration through token is supported,
-and initiates the registration flow:
+### Registration protocol
 
-```xml
-<iq type="set" to="example.com" id="pa1">
-  <preauth xmlns='urn:xmpp:pars:0' token='3c7efeafc1bb10d034' />
-</iq>
-```
+The account-only and account-and-subscription invitation types allow a recipient
+to create an account on a server (which may otherwise have closed registration).
+XMPP clients can use these invitation types to create an account by following
+the protocol in [XEP-0445][].
 
-Upon receiving the preauth request, the server should validate that the
-token is acceptable for account registration. However single-use tokens
-MUST NOT be considered used until the actual registration has succeeded.
+## Creating an invitation
 
-In addition, if the token has an expiration time, it MUST only be checked
-at this point. Subsequent actions performed by the client during the current
-session that require a valid token MUST NOT be rejected due to token expiry.
+To create an invitation, use [XEP-0401: Ad-hoc Account Invitation Generation][XEP-0401].
+Your server may also provide a mechanism (e.g. web interface or command-line
+utility) to create invitations.
 
-Server responds with success, and indicates
-the client may now proceed with account registration:
+Services may restrict the types of invitation that can be created, depending
+on policy. E.g. private servers may allow anyone to create contact invitations,
+but only allow administrators to create account invitations.
 
-```xml
-<iq type="result" from="example.com" id="pa1" />
-```
+When using XEP-0401, the server will provide at minimum an `xmpp:` URI that can be interpreted by any compatible XMPP client. However this URI SHOULD NOT be shared directly by clients. It is generally likely that the recipient of an invite does not yet have an XMPP client installed and configured.
 
-If the token provided by the client was unknown, invalid or expired, the
-server should return an appropriate error to the client:
-
-```xml
-<iq type="error" from="example.com" id="pa1">
-  <error type='cancel'>
-    <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>
-    <text>The provided token is invalid or expired</text>
-  </error>
-</iq>
-```
-
-In the success case, the client proceeds with registration using e.g.
-XEP-0077 in the normal way.
-
-# Creating an invitation
-
-Users may request an invite (suitable for sharing to a desired new contact)
-by using the ad-hoc command defined in [XEP-0401: Easy User Onboarding](https://xmpp.org/extensions/xep-0401.html#create-invitation).
-
-The server will provide at minimum an `xmpp:` URI that can be interpreted by any compatible XMPP client. However this URI SHOULD NOT be shared directly by clients. It is generally likely that the recipient of an invite does not yet have an XMPP client installed and configured.
-
-If the server provides a `landing-url` in the response, the client SHOULD share this URL with contacts. Otherwise it SHOULD use the URI in combination with a landing page (which may be hosted by the client developer or other entity) to generate a `https://` URL suitable for sharing. An example landing page can be found at [ge0rg/easy-xmpp-invitation](https://github.com/ge0rg/easy-xmpp-invitation).
-
+Instead, if the server provides a `landing-url` in the response, the client SHOULD share this URL with contacts. Otherwise it SHOULD use the URI in combination with a landing page (which may be hosted by the client developer or other entity) to generate a `https://` URL suitable for sharing. One such landing page implementation can be found at [ge0rg/easy-xmpp-invitation](https://github.com/ge0rg/easy-xmpp-invitation).
 Sharing the URL can be done by visually displaying a QR code on the user's screen (if the contact is in physical proximity) or e.g. through the platform's own sharing mechanism (to share via SMS, email, social apps, etc.)
 
 ## Guidance for landing pages
@@ -127,3 +113,7 @@ If it is possible for a particular platform's download links to automatically re
 If possible, platform detection should be used to highlight download links relevant to the user's current platform.
 
 If the detected platform is a desktop environment, consider also adding a QR code for easy transmission to a user's mobile device.
+
+[XEP-0401]: https://xmpp.org/extensions/xep-0401.html "Ad-hoc Account Invitation Generation"
+[XEP-0445]: https://xmpp.org/extensions/xep-0445.html "Pre-Authenticated In-Band Registration"
+[XEP-0379]: https://xmpp.org/extensions/xep-0379.html "Pre-Authenticated Roster Subscription"


### PR DESCRIPTION
The main difference is that XEP-0445 has been published, and we don't need to document the registration protocol here any more.

I've also cleaned up the page structure, and added better descriptions of the invitation types.